### PR TITLE
Implement skeleton pages for activity prototype

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,31 +1,31 @@
 import React, { useEffect } from 'react';
-import {
-  Routes,
-  Route,
-  useLocation
-} from 'react-router-dom';
+import { Routes, Route, useLocation } from 'react-router-dom';
 
 import './css/style.css';
-
 import './charts/ChartjsConfig';
 
-// Import pages
-import Dashboard from './pages/Dashboard';
+import Login from './pages/Login';
+import ActivityDashboard from './pages/ActivityDashboard';
+import TeamDashboard from './pages/TeamDashboard';
+import EditActivity from './pages/EditActivity';
 
 function App() {
-
   const location = useLocation();
 
   useEffect(() => {
-    document.querySelector('html').style.scrollBehavior = 'auto'
-    window.scroll({ top: 0 })
-    document.querySelector('html').style.scrollBehavior = ''
-  }, [location.pathname]); // triggered on route change
+    document.querySelector('html').style.scrollBehavior = 'auto';
+    window.scroll({ top: 0 });
+    document.querySelector('html').style.scrollBehavior = '';
+  }, [location.pathname]);
 
   return (
     <>
       <Routes>
-        <Route exact path="/" element={<Dashboard />} />
+        <Route path="/" element={<Login />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/activity" element={<ActivityDashboard />} />
+        <Route path="/team" element={<TeamDashboard />} />
+        <Route path="/edit" element={<EditActivity />} />
       </Routes>
     </>
   );

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -136,3 +136,6 @@
     border-color: var(--color-gray-200, currentColor);
   }
 }
+.btn-primary{ @apply bg-violet-500 text-white px-3 py-1 rounded; }
+.btn-secondary{ @apply bg-gray-200 text-gray-800 px-3 py-1 rounded; }
+

--- a/src/pages/ActivityDashboard.jsx
+++ b/src/pages/ActivityDashboard.jsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import Navigation from '../partials/Navigation';
+
+const sampleData = [
+  { time: '09:00', task: 'Email', duration: '10m' },
+  { time: '09:10', task: 'Coding', duration: '50m' },
+];
+
+function ActivityDashboard() {
+  const [offline, setOffline] = useState(false);
+  return (
+    <div className="flex min-h-screen">
+      <Navigation />
+      <main className="flex-1 p-4 space-y-4">
+        {offline && <div className="bg-yellow-200 p-2 rounded">Offline - syncing when connection resumes</div>}
+        <table className="min-w-full border">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="p-2 border">Timestamp</th>
+              <th className="p-2 border">Task</th>
+              <th className="p-2 border">Duration</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sampleData.map((row, idx) => (
+              <tr key={idx} className="border-t">
+                <td className="p-2 border">{row.time}</td>
+                <td className="p-2 border">{row.task}</td>
+                <td className="p-2 border">{row.duration}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="space-x-2">
+          <button className="btn-primary">Sync Now</button>
+          <button className="btn-secondary">Retry Upload</button>
+        </div>
+      </main>
+    </div>
+  );
+}
+
+export default ActivityDashboard;

--- a/src/pages/EditActivity.jsx
+++ b/src/pages/EditActivity.jsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import Navigation from '../partials/Navigation';
+
+const initial = [
+  { date: '2024-01-01', start: '09:00', end: '10:00', desc: 'Email' },
+];
+
+function EditActivity() {
+  const [rows, setRows] = useState(initial);
+  const [editing, setEditing] = useState(null);
+
+  const handleSave = (idx) => {
+    setEditing(null);
+  };
+
+  return (
+    <div className="flex min-h-screen">
+      <Navigation />
+      <main className="flex-1 p-4 space-y-4">
+        <h2 className="text-xl font-bold">Edit Activity</h2>
+        <table className="min-w-full border">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="p-2 border">Date</th>
+              <th className="p-2 border">Start</th>
+              <th className="p-2 border">End</th>
+              <th className="p-2 border">Description</th>
+              <th className="p-2 border"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, idx) => (
+              <tr key={idx} className="border-t">
+                <td className="p-2 border">{row.date}</td>
+                <td className="p-2 border">
+                  {editing === idx ? (
+                    <input type="time" defaultValue={row.start} className="border p-1" />
+                  ) : (
+                    row.start
+                  )}
+                </td>
+                <td className="p-2 border">
+                  {editing === idx ? (
+                    <input type="time" defaultValue={row.end} className="border p-1" />
+                  ) : (
+                    row.end
+                  )}
+                </td>
+                <td className="p-2 border">
+                  {editing === idx ? (
+                    <input defaultValue={row.desc} className="border p-1" />
+                  ) : (
+                    row.desc
+                  )}
+                </td>
+                <td className="p-2 border">
+                  {editing === idx ? (
+                    <>
+                      <button className="btn-primary mr-1" onClick={() => handleSave(idx)}>Save</button>
+                      <button className="btn-secondary" onClick={() => setEditing(null)}>Cancel</button>
+                    </>
+                  ) : (
+                    <button className="btn-primary" onClick={() => setEditing(idx)}>Edit</button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="text-sm text-gray-500">You can only edit your own logs.</div>
+        <button className="btn-secondary">View Audit Log</button>
+      </main>
+    </div>
+  );
+}
+
+export default EditActivity;

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+
+function Login() {
+  const [error, setError] = useState('');
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    // Placeholder for authentication logic
+    setError('Incorrect credentials');
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow w-full max-w-sm space-y-4">
+        <h1 className="text-xl font-bold text-center">Login</h1>
+        <input type="email" placeholder="Email" className="w-full border p-2 rounded" required />
+        <input type="password" placeholder="Password" className="w-full border p-2 rounded" required />
+        {error && <div className="text-red-500 text-sm">{error}</div>}
+        <button type="submit" className="btn-primary w-full">Login</button>
+        <button type="button" className="btn-secondary w-full">Face Recognition (placeholder)</button>
+      </form>
+    </div>
+  );
+}
+
+export default Login;

--- a/src/pages/TeamDashboard.jsx
+++ b/src/pages/TeamDashboard.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import Navigation from '../partials/Navigation';
+
+const data = [
+  { user: 'Alice', status: 'Active', tasks: 5, duration: '3h' },
+  { user: 'Bob', status: 'Idle', tasks: 2, duration: '1h' },
+];
+
+function TeamDashboard() {
+  return (
+    <div className="flex min-h-screen">
+      <Navigation />
+      <main className="flex-1 p-4">
+        <h2 className="text-xl font-bold mb-4">Team Dashboard</h2>
+        <table className="min-w-full border">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="p-2 border">Member</th>
+              <th className="p-2 border">Status</th>
+              <th className="p-2 border">Tasks Today</th>
+              <th className="p-2 border">Duration</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((row, idx) => (
+              <tr key={idx} className="border-t">
+                <td className="p-2 border">{row.user}</td>
+                <td className="p-2 border">{row.status}</td>
+                <td className="p-2 border">{row.tasks}</td>
+                <td className="p-2 border">{row.duration}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="mt-2 text-sm text-gray-500">WebSocket indicator (placeholder)</div>
+      </main>
+    </div>
+  );
+}
+
+export default TeamDashboard;

--- a/src/partials/Navigation.jsx
+++ b/src/partials/Navigation.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+function Navigation() {
+  const linkClass = ({ isActive }) => `block py-1 ${isActive ? 'font-bold' : ''}`;
+  return (
+    <nav className="w-48 bg-gray-800 text-white min-h-screen p-4 space-y-2">
+      <div className="font-bold text-xl mb-4">Logo</div>
+      <NavLink to="/activity" className={linkClass}>Dashboard</NavLink>
+      <NavLink to="/edit" className={linkClass}>Edit</NavLink>
+      <NavLink to="/team" className={linkClass}>Team</NavLink>
+      <NavLink to="/login" className={linkClass}>Logout</NavLink>
+    </nav>
+  );
+}
+
+export default Navigation;


### PR DESCRIPTION
## Summary
- add basic login page
- implement activity dashboard
- add team dashboard page
- create edit activity page with inline editing
- add simple navigation component
- add button utility classes
- hook new routes into `App.jsx`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_68519b7cf628832da492c7b8f8123676